### PR TITLE
Reorder to put identity bindings first

### DIFF
--- a/draft-ietf-mmusic-sdp-uks.md
+++ b/draft-ietf-mmusic-sdp-uks.md
@@ -118,7 +118,7 @@ communicate with a different peer, even though it believes that it is
 communicating with the malicious endpoint.
 
 When the identity of communicating peers is established by higher-layer
-signaling constructs, such as those in SIP identity {{?RFC8224}} or WebRTC
+signaling constructs, such as those in SIP identity {{?SIP-ID}} or WebRTC
 {{!WEBRTC-SEC}}, this allows an attacker to bind their own identity to a session
 with any other entity.
 
@@ -278,9 +278,9 @@ conduct two sessions concurrently, if the attacker (Mallory) is on the network
 path between the victims, and if the same certificate - and therefore SDP
 `fingerprint` attribute value - is used in both sessions.
 
-Where ICE {{?ICE=I-D.ietf-ice-rfc5245bis}} is used, Mallory also needs to ensure
-that connectivity between Patsy and Norma succeed, either by forwarding checks
-or answering and generating the necessary messages.
+Where ICE {{?ICE=RFC8445}} is used, Mallory also needs to ensure that
+connectivity between Patsy and Norma succeed, either by forwarding checks or
+answering and generating the necessary messages.
 
 
 ## Interactions with Key Continuity {#continuity}

--- a/draft-ietf-mmusic-sdp-uks.md
+++ b/draft-ietf-mmusic-sdp-uks.md
@@ -99,6 +99,11 @@ external identity bound to fingerprints, like that defined in WebRTC identity
 (see Section 7 of {{!WEBRTC-SEC=I-D.ietf-rtcweb-security-arch}}) or SIP identity
 {{?SIP-ID=RFC8224}}.
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
+
 
 # Unknown Key-Share Attack
 


### PR DESCRIPTION
I did some reframing to justify this organization.  This probably needs
another review.

Attn. @adamroach - [preview of complete draft](https://martinthomson.github.io/sdp-uks/reorder/draft-ietf-mmusic-sdp-uks.html) because the [diff](https://tools.ietf.org/rfcdiff?url1=https://martinthomson.github.io/sdp-uks/draft-ietf-mmusic-sdp-uks.txt&url2=https://martinthomson.github.io/sdp-uks/reorder/draft-ietf-mmusic-sdp-uks.txt) is pretty hard to follow.